### PR TITLE
Add administrative city management

### DIFF
--- a/admin/controller/common/column_left.php
+++ b/admin/controller/common/column_left.php
@@ -563,6 +563,13 @@ class ControllerCommonColumnLeft extends Controller {
 					'children' => array()
 				);
 			}
+                        if ($this->user->hasPermission('access', 'localisation/city')) {
+                                $localisation[] = array(
+                                        'name'     => $this->language->get('text_city'),
+                                        'href'     => $this->url->link('localisation/city', 'user_token=' . $this->session->data['user_token'], true),
+                                        'children' => array()
+                                );
+                        }
 
 			if ($this->user->hasPermission('access', 'localisation/geo_zone')) {
 				$localisation[] = array(

--- a/admin/controller/localisation/city.php
+++ b/admin/controller/localisation/city.php
@@ -1,0 +1,415 @@
+<?php
+class ControllerLocalisationCity extends Controller {
+    private $error = array();
+
+    public function index() {
+        $this->load->language('localisation/city');
+
+        $this->document->setTitle($this->language->get('heading_title'));
+
+        $this->load->model('localisation/city');
+
+        $this->getList();
+    }
+
+    public function add() {
+        $this->load->language('localisation/city');
+
+        $this->document->setTitle($this->language->get('heading_title'));
+
+        $this->load->model('localisation/city');
+
+        if (($this->request->server['REQUEST_METHOD'] == 'POST') && $this->validateForm()) {
+            $this->model_localisation_city->addCity($this->request->post);
+
+            $this->session->data['success'] = $this->language->get('text_success');
+
+            $url = '';
+
+            if (isset($this->request->get['sort'])) {
+                $url .= '&sort=' . $this->request->get['sort'];
+            }
+
+            if (isset($this->request->get['order'])) {
+                $url .= '&order=' . $this->request->get['order'];
+            }
+
+            if (isset($this->request->get['page'])) {
+                $url .= '&page=' . $this->request->get['page'];
+            }
+
+            if (isset($this->request->get['filter_name'])) {
+                $url .= '&filter_name=' . urlencode(html_entity_decode($this->request->get['filter_name'], ENT_QUOTES, 'UTF-8'));
+            }
+
+            $this->response->redirect($this->url->link('localisation/city', 'user_token=' . $this->session->data['user_token'] . $url, true));
+        }
+
+        $this->getForm();
+    }
+
+    public function edit() {
+        $this->load->language('localisation/city');
+
+        $this->document->setTitle($this->language->get('heading_title'));
+
+        $this->load->model('localisation/city');
+
+        if (($this->request->server['REQUEST_METHOD'] == 'POST') && $this->validateForm()) {
+            $this->model_localisation_city->editCity($this->request->get['city_id'], $this->request->post);
+
+            $this->session->data['success'] = $this->language->get('text_success');
+
+            $url = '';
+
+            if (isset($this->request->get['sort'])) {
+                $url .= '&sort=' . $this->request->get['sort'];
+            }
+
+            if (isset($this->request->get['order'])) {
+                $url .= '&order=' . $this->request->get['order'];
+            }
+
+            if (isset($this->request->get['page'])) {
+                $url .= '&page=' . $this->request->get['page'];
+            }
+
+            if (isset($this->request->get['filter_name'])) {
+                $url .= '&filter_name=' . urlencode(html_entity_decode($this->request->get['filter_name'], ENT_QUOTES, 'UTF-8'));
+            }
+
+            $this->response->redirect($this->url->link('localisation/city', 'user_token=' . $this->session->data['user_token'] . $url, true));
+        }
+
+        $this->getForm();
+    }
+
+    public function delete() {
+        $this->load->language('localisation/city');
+
+        $this->document->setTitle($this->language->get('heading_title'));
+
+        $this->load->model('localisation/city');
+
+        if (isset($this->request->post['selected']) && $this->validateDelete()) {
+            foreach ($this->request->post['selected'] as $city_id) {
+                $this->model_localisation_city->deleteCity($city_id);
+            }
+
+            $this->session->data['success'] = $this->language->get('text_success');
+
+            $url = '';
+
+            if (isset($this->request->get['sort'])) {
+                $url .= '&sort=' . $this->request->get['sort'];
+            }
+
+            if (isset($this->request->get['order'])) {
+                $url .= '&order=' . $this->request->get['order'];
+            }
+
+            if (isset($this->request->get['page'])) {
+                $url .= '&page=' . $this->request->get['page'];
+            }
+
+            if (isset($this->request->get['filter_name'])) {
+                $url .= '&filter_name=' . urlencode(html_entity_decode($this->request->get['filter_name'], ENT_QUOTES, 'UTF-8'));
+            }
+
+            $this->response->redirect($this->url->link('localisation/city', 'user_token=' . $this->session->data['user_token'] . $url, true));
+        }
+
+        $this->getList();
+    }
+
+    protected function getList() {
+        if (isset($this->request->get['filter_name'])) {
+            $filter_name = $this->request->get['filter_name'];
+        } else {
+            $filter_name = '';
+        }
+
+        if (isset($this->request->get['sort'])) {
+            $sort = $this->request->get['sort'];
+        } else {
+            $sort = 'name';
+        }
+
+        if (isset($this->request->get['order'])) {
+            $order = $this->request->get['order'];
+        } else {
+            $order = 'ASC';
+        }
+
+        if (isset($this->request->get['page'])) {
+            $page = (int)$this->request->get['page'];
+        } else {
+            $page = 1;
+        }
+
+        $url = '';
+
+        if ($filter_name) {
+            $url .= '&filter_name=' . urlencode(html_entity_decode($filter_name, ENT_QUOTES, 'UTF-8'));
+        }
+
+        if ($sort) {
+            $url .= '&sort=' . $sort;
+        }
+
+        if ($order) {
+            $url .= '&order=' . $order;
+        }
+
+        if ($page) {
+            $url .= '&page=' . $page;
+        }
+
+        $data['breadcrumbs'] = array();
+
+        $data['breadcrumbs'][] = array(
+            'text' => $this->language->get('text_home'),
+            'href' => $this->url->link('common/dashboard', 'user_token=' . $this->session->data['user_token'], true)
+        );
+
+        $data['breadcrumbs'][] = array(
+            'text' => $this->language->get('heading_title'),
+            'href' => $this->url->link('localisation/city', 'user_token=' . $this->session->data['user_token'] . $url, true)
+        );
+
+        $data['add'] = $this->url->link('localisation/city/add', 'user_token=' . $this->session->data['user_token'] . $url, true);
+        $data['delete'] = $this->url->link('localisation/city/delete', 'user_token=' . $this->session->data['user_token'] . $url, true);
+
+        $data['cities'] = array();
+
+        $filter_data = array(
+            'filter_name' => $filter_name,
+            'sort'  => $sort,
+            'order' => $order,
+            'start' => ($page - 1) * $this->config->get('config_limit_admin'),
+            'limit' => $this->config->get('config_limit_admin')
+        );
+
+        $city_total = $this->model_localisation_city->getTotalCities($filter_data);
+
+        $results = $this->model_localisation_city->getCities($filter_data);
+
+        foreach ($results as $result) {
+            $data['cities'][] = array(
+                'city_id' => $result['city_id'],
+                'name'    => $result['name'],
+                'keyword' => $result['keyword'],
+                'status'  => $result['status'],
+                'edit'    => $this->url->link('localisation/city/edit', 'user_token=' . $this->session->data['user_token'] . '&city_id=' . $result['city_id'] . $url, true)
+            );
+        }
+
+        $data['heading_title'] = $this->language->get('heading_title');
+
+        $data['text_list'] = $this->language->get('text_list');
+        $data['text_no_results'] = $this->language->get('text_no_results');
+        $data['text_confirm'] = $this->language->get('text_confirm');
+
+        $data['column_name'] = $this->language->get('column_name');
+        $data['column_keyword'] = $this->language->get('column_keyword');
+        $data['column_status'] = $this->language->get('column_status');
+        $data['column_action'] = $this->language->get('column_action');
+
+        $data['entry_name'] = $this->language->get('entry_name');
+
+        $data['button_add'] = $this->language->get('button_add');
+        $data['button_edit'] = $this->language->get('button_edit');
+        $data['button_delete'] = $this->language->get('button_delete');
+        $data['button_filter'] = $this->language->get('button_filter');
+
+        $data['user_token'] = $this->session->data['user_token'];
+
+        if (isset($this->error['warning'])) {
+            $data['error_warning'] = $this->error['warning'];
+        } else {
+            $data['error_warning'] = '';
+        }
+
+        if (isset($this->session->data['success'])) {
+            $data['success'] = $this->session->data['success'];
+
+            unset($this->session->data['success']);
+        } else {
+            $data['success'] = '';
+        }
+
+        $data['selected'] = isset($this->request->post['selected']) ? (array)$this->request->post['selected'] : array();
+
+        $url = '';
+
+        if ($filter_name) {
+            $url .= '&filter_name=' . urlencode(html_entity_decode($filter_name, ENT_QUOTES, 'UTF-8'));
+        }
+
+        if ($sort) {
+            $url .= '&sort=' . $sort;
+        }
+
+        if ($order == 'ASC') {
+            $url .= '&order=DESC';
+        } else {
+            $url .= '&order=ASC';
+        }
+
+        if ($page) {
+            $url .= '&page=' . $page;
+        }
+
+        $data['sort_name'] = $this->url->link('localisation/city', 'user_token=' . $this->session->data['user_token'] . '&sort=name' . $url, true);
+        $data['sort_keyword'] = $this->url->link('localisation/city', 'user_token=' . $this->session->data['user_token'] . '&sort=keyword' . $url, true);
+        $data['sort_status'] = $this->url->link('localisation/city', 'user_token=' . $this->session->data['user_token'] . '&sort=status' . $url, true);
+
+        $url = '';
+
+        if ($filter_name) {
+            $url .= '&filter_name=' . urlencode(html_entity_decode($filter_name, ENT_QUOTES, 'UTF-8'));
+        }
+
+        if ($sort) {
+            $url .= '&sort=' . $sort;
+        }
+
+        if ($order) {
+            $url .= '&order=' . $order;
+        }
+
+        $pagination = new Pagination();
+        $pagination->total = $city_total;
+        $pagination->page = $page;
+        $pagination->limit = $this->config->get('config_limit_admin');
+        $pagination->url = $this->url->link('localisation/city', 'user_token=' . $this->session->data['user_token'] . $url . '&page={page}', true);
+
+        $data['pagination'] = $pagination->render();
+
+        $data['results'] = sprintf($this->language->get('text_pagination'), ($city_total) ? (($page - 1) * $this->config->get('config_limit_admin')) + 1 : 0, ((($page - 1) * $this->config->get('config_limit_admin')) > ($city_total - $this->config->get('config_limit_admin'))) ? $city_total : ((($page - 1) * $this->config->get('config_limit_admin')) + $this->config->get('config_limit_admin')), $city_total, ceil($city_total / $this->config->get('config_limit_admin')));
+
+        $data['filter_name'] = $filter_name;
+        $data['sort'] = $sort;
+        $data['order'] = $order;
+
+        $this->response->setOutput($this->load->view('localisation/city_list', $data));
+    }
+
+    protected function getForm() {
+        $data['heading_title'] = $this->language->get('heading_title');
+
+        $data['text_form'] = !isset($this->request->get['city_id']) ? $this->language->get('text_add') : $this->language->get('text_edit');
+
+        $data['entry_name'] = $this->language->get('entry_name');
+        $data['entry_keyword'] = $this->language->get('entry_keyword');
+        $data['entry_status'] = $this->language->get('entry_status');
+
+        $data['text_enabled'] = $this->language->get('text_enabled');
+        $data['text_disabled'] = $this->language->get('text_disabled');
+
+        $data['button_save'] = $this->language->get('button_save');
+        $data['button_cancel'] = $this->language->get('button_cancel');
+
+        if (isset($this->error['warning'])) {
+            $data['error_warning'] = $this->error['warning'];
+        } else {
+            $data['error_warning'] = '';
+        }
+
+        if (isset($this->error['name'])) {
+            $data['error_name'] = $this->error['name'];
+        } else {
+            $data['error_name'] = '';
+        }
+
+        $url = '';
+
+        if (isset($this->request->get['filter_name'])) {
+            $url .= '&filter_name=' . urlencode(html_entity_decode($this->request->get['filter_name'], ENT_QUOTES, 'UTF-8'));
+        }
+
+        if (isset($this->request->get['sort'])) {
+            $url .= '&sort=' . $this->request->get['sort'];
+        }
+
+        if (isset($this->request->get['order'])) {
+            $url .= '&order=' . $this->request->get['order'];
+        }
+
+        if (isset($this->request->get['page'])) {
+            $url .= '&page=' . $this->request->get['page'];
+        }
+
+        $data['breadcrumbs'] = array();
+
+        $data['breadcrumbs'][] = array(
+            'text' => $this->language->get('text_home'),
+            'href' => $this->url->link('common/dashboard', 'user_token=' . $this->session->data['user_token'], true)
+        );
+
+        $data['breadcrumbs'][] = array(
+            'text' => $this->language->get('heading_title'),
+            'href' => $this->url->link('localisation/city', 'user_token=' . $this->session->data['user_token'] . $url, true)
+        );
+
+        if (!isset($this->request->get['city_id'])) {
+            $data['action'] = $this->url->link('localisation/city/add', 'user_token=' . $this->session->data['user_token'] . $url, true);
+        } else {
+            $data['action'] = $this->url->link('localisation/city/edit', 'user_token=' . $this->session->data['user_token'] . '&city_id=' . $this->request->get['city_id'] . $url, true);
+        }
+
+        $data['cancel'] = $this->url->link('localisation/city', 'user_token=' . $this->session->data['user_token'] . $url, true);
+
+        if (isset($this->request->get['city_id']) && ($this->request->server['REQUEST_METHOD'] != 'POST')) {
+            $city_info = $this->model_localisation_city->getCity($this->request->get['city_id']);
+        }
+
+        if (isset($this->request->post['name'])) {
+            $data['name'] = $this->request->post['name'];
+        } elseif (!empty($city_info)) {
+            $data['name'] = $city_info['name'];
+        } else {
+            $data['name'] = '';
+        }
+
+        if (isset($this->request->post['keyword'])) {
+            $data['keyword'] = $this->request->post['keyword'];
+        } elseif (!empty($city_info)) {
+            $data['keyword'] = $city_info['keyword'];
+        } else {
+            $data['keyword'] = '';
+        }
+
+        if (isset($this->request->post['status'])) {
+            $data['status'] = $this->request->post['status'];
+        } elseif (!empty($city_info)) {
+            $data['status'] = $city_info['status'];
+        } else {
+            $data['status'] = 1;
+        }
+
+        $data['user_token'] = $this->session->data['user_token'];
+
+        $this->response->setOutput($this->load->view('localisation/city_form', $data));
+    }
+
+    protected function validateForm() {
+        if (!$this->user->hasPermission('modify', 'localisation/city')) {
+            $this->error['warning'] = $this->language->get('error_permission');
+        }
+
+        if ((utf8_strlen($this->request->post['name']) < 1) || (utf8_strlen($this->request->post['name']) > 64)) {
+            $this->error['name'] = $this->language->get('error_name');
+        }
+
+        return !$this->error;
+    }
+
+    protected function validateDelete() {
+        if (!$this->user->hasPermission('modify', 'localisation/city')) {
+            $this->error['warning'] = $this->language->get('error_permission');
+        }
+
+        return !$this->error;
+    }
+}

--- a/admin/language/en-gb/common/column_left.php
+++ b/admin/language/en-gb/common/column_left.php
@@ -69,6 +69,7 @@ $_['text_voucher_theme']        = 'Voucher Themes';
 $_['text_weight_class']         = 'Weight Classes';
 $_['text_length_class']         = 'Length Classes';
 $_['text_zone']                 = 'Zones';
+$_['text_city']                 = 'Cities';
 $_['text_recurring']            = 'Recurring Profiles';
 $_['text_order_recurring']      = 'Recurring Orders';
 $_['text_complete_status']      = 'Orders Completed';

--- a/admin/language/en-gb/localisation/city.php
+++ b/admin/language/en-gb/localisation/city.php
@@ -1,0 +1,24 @@
+<?php
+// Heading
+$_['heading_title']     = 'Cities';
+
+// Text
+$_['text_success']      = 'Success: You have modified cities!';
+$_['text_list']         = 'City List';
+$_['text_add']          = 'Add City';
+$_['text_edit']         = 'Edit City';
+
+// Column
+$_['column_name']       = 'City Name';
+$_['column_keyword']    = 'SEO Keyword';
+$_['column_status']     = 'Status';
+$_['column_action']     = 'Action';
+
+// Entry
+$_['entry_name']        = 'City Name';
+$_['entry_keyword']     = 'SEO Keyword';
+$_['entry_status']      = 'Status';
+
+// Error
+$_['error_permission']  = 'Warning: You do not have permission to modify cities!';
+$_['error_name']        = 'City Name must be between 1 and 64 characters!';

--- a/admin/language/pl-pl/common/column_left.php
+++ b/admin/language/pl-pl/common/column_left.php
@@ -107,6 +107,7 @@ $_['text_voucher_theme'] = 'Motyw';
 $_['text_weight_class'] = 'Jednostki wagi';
 $_['text_length_class'] = 'Jednostki';
 $_['text_zone'] = 'Regiony';
+$_['text_city'] = 'Miasta';
 $_['text_recurring'] = 'Płatności cykliczne';
 $_['text_order_recurring'] = 'Zamówienia cykliczne';
 $_['text_openbay_extension'] = 'OpenBay Pro';

--- a/admin/language/pl-pl/localisation/city.php
+++ b/admin/language/pl-pl/localisation/city.php
@@ -1,0 +1,24 @@
+<?php
+// Heading
+$_['heading_title']     = 'Miasta';
+
+// Text
+$_['text_success']      = 'Sukces: zmodyfikowano miasta!';
+$_['text_list']         = 'Lista miast';
+$_['text_add']          = 'Dodaj miasto';
+$_['text_edit']         = 'Edytuj miasto';
+
+// Column
+$_['column_name']       = 'Nazwa miasta';
+$_['column_keyword']    = 'Słowo kluczowe SEO';
+$_['column_status']     = 'Status';
+$_['column_action']     = 'Akcja';
+
+// Entry
+$_['entry_name']        = 'Nazwa miasta';
+$_['entry_keyword']     = 'Słowo kluczowe SEO';
+$_['entry_status']      = 'Status';
+
+// Error
+$_['error_permission']  = 'Ostrzeżenie: nie masz uprawnień do modyfikacji miast!';
+$_['error_name']        = 'Nazwa miasta musi mieć od 1 do 64 znaków!';

--- a/admin/language/ru-ru/common/column_left.php
+++ b/admin/language/ru-ru/common/column_left.php
@@ -107,6 +107,7 @@ $_['text_voucher_theme']               = 'Тематика';
 $_['text_weight_class']                = 'Единицы веса';
 $_['text_length_class']                = 'Единицы измерения';
 $_['text_zone']                        = 'Регионы';
+$_['text_city']                        = 'Города';
 $_['text_recurring']                   = 'Регулярные платежи';
 $_['text_order_recurring']             = 'Периодические заказы';
 $_['text_openbay_extension']           = 'OpenBay Pro';

--- a/admin/language/ru-ru/localisation/city.php
+++ b/admin/language/ru-ru/localisation/city.php
@@ -1,0 +1,24 @@
+<?php
+// Heading
+$_['heading_title']     = 'Города';
+
+// Text
+$_['text_success']      = 'Настройки успешно изменены!';
+$_['text_list']         = 'Список городов';
+$_['text_add']          = 'Добавить город';
+$_['text_edit']         = 'Редактировать город';
+
+// Column
+$_['column_name']       = 'Название города';
+$_['column_keyword']    = 'SEO ключевое слово';
+$_['column_status']     = 'Статус';
+$_['column_action']     = 'Действие';
+
+// Entry
+$_['entry_name']        = 'Название города';
+$_['entry_keyword']     = 'SEO ключевое слово';
+$_['entry_status']      = 'Статус';
+
+// Error
+$_['error_permission']  = 'У вас нет прав для изменения городов!';
+$_['error_name']        = 'Название города должно быть от 1 до 64 символов!';

--- a/admin/model/localisation/city.php
+++ b/admin/model/localisation/city.php
@@ -1,0 +1,72 @@
+<?php
+class ModelLocalisationCity extends Model {
+    public function addCity($data) {
+        $this->db->query("INSERT INTO " . DB_PREFIX . "city SET name = '" . $this->db->escape($data['name']) . "', keyword = '" . $this->db->escape($data['keyword']) . "', status = '" . (int)$data['status'] . "'");
+
+        return $this->db->getLastId();
+    }
+
+    public function editCity($city_id, $data) {
+        $this->db->query("UPDATE " . DB_PREFIX . "city SET name = '" . $this->db->escape($data['name']) . "', keyword = '" . $this->db->escape($data['keyword']) . "', status = '" . (int)$data['status'] . "' WHERE city_id = '" . (int)$city_id . "'");
+    }
+
+    public function deleteCity($city_id) {
+        $this->db->query("DELETE FROM " . DB_PREFIX . "city WHERE city_id = '" . (int)$city_id . "'");
+    }
+
+    public function getCity($city_id) {
+        $query = $this->db->query("SELECT DISTINCT * FROM " . DB_PREFIX . "city WHERE city_id = '" . (int)$city_id . "'");
+
+        return $query->row;
+    }
+
+    public function getCities($data = array()) {
+        $sql = "SELECT * FROM " . DB_PREFIX . "city";
+
+        if (!empty($data['filter_name'])) {
+            $sql .= " WHERE name LIKE '" . $this->db->escape($data['filter_name']) . "%'";
+        }
+
+        $sort_data = array('name', 'keyword', 'status');
+
+        if (isset($data['sort']) && in_array($data['sort'], $sort_data)) {
+            $sql .= " ORDER BY " . $data['sort'];
+        } else {
+            $sql .= " ORDER BY name";
+        }
+
+        if (isset($data['order']) && ($data['order'] == 'DESC')) {
+            $sql .= " DESC";
+        } else {
+            $sql .= " ASC";
+        }
+
+        if (isset($data['start']) || isset($data['limit'])) {
+            if ($data['start'] < 0) {
+                $data['start'] = 0;
+            }
+
+            if ($data['limit'] < 1) {
+                $data['limit'] = 20;
+            }
+
+            $sql .= " LIMIT " . (int)$data['start'] . "," . (int)$data['limit'];
+        }
+
+        $query = $this->db->query($sql);
+
+        return $query->rows;
+    }
+
+    public function getTotalCities($data = array()) {
+        $sql = "SELECT COUNT(*) AS total FROM " . DB_PREFIX . "city";
+
+        if (!empty($data['filter_name'])) {
+            $sql .= " WHERE name LIKE '" . $this->db->escape($data['filter_name']) . "%'";
+        }
+
+        $query = $this->db->query($sql);
+
+        return $query->row['total'];
+    }
+}

--- a/admin/view/template/localisation/city_form.twig
+++ b/admin/view/template/localisation/city_form.twig
@@ -1,0 +1,62 @@
+{{ header }}{{ column_left }}
+<div id="content">
+  <div class="page-header">
+    <div class="container-fluid">
+      <div class="pull-right">
+        <button type="submit" form="form-city" data-toggle="tooltip" title="{{ button_save }}" class="btn btn-primary"><i class="fa fa-save"></i></button>
+        <a href="{{ cancel }}" data-toggle="tooltip" title="{{ button_cancel }}" class="btn btn-default"><i class="fa fa-reply"></i></a></div>
+      <h1>{{ heading_title }}</h1>
+      <ul class="breadcrumb">
+        {% for breadcrumb in breadcrumbs %}
+        <li><a href="{{ breadcrumb.href }}">{{ breadcrumb.text }}</a></li>
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+  <div class="container-fluid">
+    {% if error_warning %}
+    <div class="alert alert-danger alert-dismissible"><i class="fa fa-exclamation-circle"></i> {{ error_warning }}
+      <button type="button" class="close" data-dismiss="alert">&times;</button>
+    </div>
+    {% endif %}
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title"><i class="fa fa-pencil"></i> {{ text_form }}</h3>
+      </div>
+      <div class="panel-body">
+        <form action="{{ action }}" method="post" enctype="multipart/form-data" id="form-city" class="form-horizontal">
+          <div class="form-group required">
+            <label class="col-sm-2 control-label" for="input-name">{{ entry_name }}</label>
+            <div class="col-sm-10">
+              <input type="text" name="name" value="{{ name }}" placeholder="{{ entry_name }}" id="input-name" class="form-control" />
+              {% if error_name %}
+              <div class="text-danger">{{ error_name }}</div>
+              {% endif %}
+            </div>
+          </div>
+          <div class="form-group">
+            <label class="col-sm-2 control-label" for="input-keyword">{{ entry_keyword }}</label>
+            <div class="col-sm-10">
+              <input type="text" name="keyword" value="{{ keyword }}" placeholder="{{ entry_keyword }}" id="input-keyword" class="form-control" />
+            </div>
+          </div>
+          <div class="form-group">
+            <label class="col-sm-2 control-label" for="input-status">{{ entry_status }}</label>
+            <div class="col-sm-10">
+              <select name="status" id="input-status" class="form-control">
+                {% if status %}
+                <option value="1" selected="selected">{{ text_enabled }}</option>
+                <option value="0">{{ text_disabled }}</option>
+                {% else %}
+                <option value="1">{{ text_enabled }}</option>
+                <option value="0" selected="selected">{{ text_disabled }}</option>
+                {% endif %}
+              </select>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+{{ footer }}

--- a/admin/view/template/localisation/city_list.twig
+++ b/admin/view/template/localisation/city_list.twig
@@ -1,0 +1,97 @@
+{{ header }}{{ column_left }}
+<div id="content">
+  <div class="page-header">
+    <div class="container-fluid">
+      <div class="pull-right"><a href="{{ add }}" data-toggle="tooltip" title="{{ button_add }}" class="btn btn-primary"><i class="fa fa-plus"></i></a>
+        <button type="button" data-toggle="tooltip" title="{{ button_delete }}" class="btn btn-danger" onclick="confirm('{{ text_confirm }}') ? $('#form-city').submit() : false;"><i class="fa fa-trash-o"></i></button>
+      </div>
+      <h1>{{ heading_title }}</h1>
+      <ul class="breadcrumb">
+        {% for breadcrumb in breadcrumbs %}
+        <li><a href="{{ breadcrumb.href }}">{{ breadcrumb.text }}</a></li>
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+  <div class="container-fluid">
+    {% if error_warning %}
+    <div class="alert alert-danger alert-dismissible"><i class="fa fa-exclamation-circle"></i> {{ error_warning }}
+      <button type="button" class="close" data-dismiss="alert">&times;</button>
+    </div>
+    {% endif %}
+    {% if success %}
+    <div class="alert alert-success alert-dismissible"><i class="fa fa-check-circle"></i> {{ success }}
+      <button type="button" class="close" data-dismiss="alert">&times;</button>
+    </div>
+    {% endif %}
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title"><i class="fa fa-list"></i> {{ text_list }}</h3>
+      </div>
+      <div class="panel-body">
+        <div class="well">
+          <div class="row">
+            <div class="col-sm-6">
+              <div class="form-group">
+                <label class="control-label" for="input-name">{{ entry_name }}</label>
+                <input type="text" name="filter_name" value="{{ filter_name }}" placeholder="{{ entry_name }}" id="input-name" class="form-control" />
+              </div>
+            </div>
+            <div class="col-sm-6">
+              <div class="form-group text-right" style="margin-top:25px;">
+                <button type="button" id="button-filter" class="btn btn-default"><i class="fa fa-filter"></i> {{ button_filter }}</button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <form action="{{ delete }}" method="post" enctype="multipart/form-data" id="form-city">
+          <div class="table-responsive">
+            <table class="table table-bordered table-hover">
+              <thead>
+                <tr>
+                  <td style="width:1px;" class="text-center"><input type="checkbox" onclick="$('input[name*=\'selected\']').prop('checked', this.checked);" /></td>
+                  <td class="text-left">{% if sort == 'name' %}<a href="{{ sort_name }}" class="{{ order|lower }}">{{ column_name }}</a>{% else %}<a href="{{ sort_name }}">{{ column_name }}</a>{% endif %}</td>
+                  <td class="text-left">{% if sort == 'keyword' %}<a href="{{ sort_keyword }}" class="{{ order|lower }}">{{ column_keyword }}</a>{% else %}<a href="{{ sort_keyword }}">{{ column_keyword }}</a>{% endif %}</td>
+                  <td class="text-left">{% if sort == 'status' %}<a href="{{ sort_status }}" class="{{ order|lower }}">{{ column_status }}</a>{% else %}<a href="{{ sort_status }}">{{ column_status }}</a>{% endif %}</td>
+                  <td class="text-right">{{ column_action }}</td>
+                </tr>
+              </thead>
+              <tbody>
+                {% if cities %}
+                {% for city in cities %}
+                <tr>
+                  <td class="text-center">{% if city.city_id in selected %}<input type="checkbox" name="selected[]" value="{{ city.city_id }}" checked="checked" />{% else %}<input type="checkbox" name="selected[]" value="{{ city.city_id }}" />{% endif %}</td>
+                  <td class="text-left">{{ city.name }}</td>
+                  <td class="text-left">{{ city.keyword }}</td>
+                  <td class="text-left">{% if city.status %}{{ text_enabled }}{% else %}{{ text_disabled }}{% endif %}</td>
+                  <td class="text-right"><a href="{{ city.edit }}" data-toggle="tooltip" title="{{ button_edit }}" class="btn btn-primary"><i class="fa fa-pencil"></i></a></td>
+                </tr>
+                {% endfor %}
+                {% else %}
+                <tr>
+                  <td class="text-center" colspan="5">{{ text_no_results }}</td>
+                </tr>
+                {% endif %}
+              </tbody>
+            </table>
+          </div>
+        </form>
+        <div class="row">
+          <div class="col-sm-6 text-left">{{ pagination }}</div>
+          <div class="col-sm-6 text-right">{{ results }}</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<script type="text/javascript"><!--
+$('#button-filter').on('click', function() {
+    url = 'index.php?route=localisation/city&user_token={{ user_token }}';
+    var filter_name = $('input[name=\'filter_name\']').val();
+    if (filter_name) {
+        url += '&filter_name=' + encodeURIComponent(filter_name);
+    }
+    location = url;
+});
+//--></script>
+{{ footer }}


### PR DESCRIPTION
## Summary
- add admin controller, model, and views for managing cities with search and CRUD
- include translations and menu entry for city management

## Testing
- `php -l admin/model/localisation/city.php`
- `php -l admin/controller/localisation/city.php`
- `php -l admin/controller/common/column_left.php`
- `php -l admin/language/en-gb/localisation/city.php`
- `php -l admin/language/ru-ru/localisation/city.php`
- `php -l admin/language/pl-pl/localisation/city.php`
- `php -l admin/language/en-gb/common/column_left.php`
- `php -l admin/language/ru-ru/common/column_left.php`
- `php -l admin/language/pl-pl/common/column_left.php`


------
https://chatgpt.com/codex/tasks/task_e_68a6b308579c83209e23dbc0eb5e29d3